### PR TITLE
BUILD_TESTING=OFF fixes

### DIFF
--- a/hep_concurrency/CMakeLists.txt
+++ b/hep_concurrency/CMakeLists.txt
@@ -44,4 +44,6 @@ cet_make_library(LIBRARY_NAME cache INTERFACE
 install_headers(SUBDIRS detail)
 install_source(SUBDIRS detail)
 
+if( ${BUILD_TESTING} )
 add_subdirectory(test)
+endif()

--- a/hep_concurrency/test/CMakeLists.txt
+++ b/hep_concurrency/test/CMakeLists.txt
@@ -31,9 +31,7 @@ foreach(test IN ITEMS
     LIBRARIES PRIVATE hep_concurrency::hep_concurrency)
 endforeach()
 
-if( ${BUILD_TESTING} )
 target_link_libraries(waiting_task_list_t PRIVATE TBB::tbb)
-endif()
 
 cet_test(simultaneous_function_spawner_t USE_CATCH2_MAIN
   LIBRARIES PRIVATE hep_concurrency::simultaneous_function_spawner
@@ -48,7 +46,5 @@ foreach (target IN ITEMS cache_handle_t cache_mt_t cache_t)
     LIBRARIES PRIVATE hep_concurrency::cache TBB::tbb)
 endforeach()
 
-if( ${BUILD_TESTING} )
 target_link_libraries(cache_handle_t PRIVATE cetlib_except::Catch2Matchers)
 target_link_libraries(cache_t PRIVATE cetlib_except::Catch2Matchers)
-endif()

--- a/hep_concurrency/test/CMakeLists.txt
+++ b/hep_concurrency/test/CMakeLists.txt
@@ -31,7 +31,9 @@ foreach(test IN ITEMS
     LIBRARIES PRIVATE hep_concurrency::hep_concurrency)
 endforeach()
 
+if( ${BUILD_TESTING} )
 target_link_libraries(waiting_task_list_t PRIVATE TBB::tbb)
+endif()
 
 cet_test(simultaneous_function_spawner_t USE_CATCH2_MAIN
   LIBRARIES PRIVATE hep_concurrency::simultaneous_function_spawner
@@ -46,5 +48,7 @@ foreach (target IN ITEMS cache_handle_t cache_mt_t cache_t)
     LIBRARIES PRIVATE hep_concurrency::cache TBB::tbb)
 endforeach()
 
+if( ${BUILD_TESTING} )
 target_link_libraries(cache_handle_t PRIVATE cetlib_except::Catch2Matchers)
 target_link_libraries(cache_t PRIVATE cetlib_except::Catch2Matchers)
+endif()


### PR DESCRIPTION
IF you don't ask spack to *run* tests, it doesn't *build* tests, so it builds with -DBUILD_TESTING=OFF.
This gives errors when you try to add libraries to a now nonexistent target.