### PR TITLE
Fix thread_sanitize constraint to match what is actually required

### DIFF
--- a/hep_concurrency/test/bad_sanitize_t.cc
+++ b/hep_concurrency/test/bad_sanitize_t.cc
@@ -3,16 +3,12 @@
 
 using namespace hep::concurrency;
 
-struct func {
-  int
-  operator()(int num)
-  {
-    return num;
-  }
+struct Obj {
+  explicit Obj(int) {}
 };
 
 int
 main()
 {
-  thread_sanitize<func> test_sanitize("invalid argument");
+  thread_sanitize<Obj> test_sanitize("invalid argument");
 }

--- a/hep_concurrency/thread_sanitize.h
+++ b/hep_concurrency/thread_sanitize.h
@@ -21,10 +21,8 @@ namespace hep {
   namespace concurrency {
 #if CET_CONCEPTS_AVAILABLE
     namespace detail {
-      template <typename Func, typename... Args>
-      concept sanitizer_compatible = requires(Func func, Args&&... args) {
-                                       requires std::invocable<Func, Args...>;
-                                     };
+      template <typename T, typename... Args>
+      concept sanitizer_compatible = std::constructible_from<T, Args...>;
     }
 #endif
 


### PR DESCRIPTION
Fixes constraint in thread_sanitize.h and revises the test bad_sanitize_t.cc to match changes in thread_sanitize.h. 
