### PR TITLE
Simplify `collection_hasher` after removal of C++<20 support

### DIFF
--- a/hep_concurrency/cache.h
+++ b/hep_concurrency/cache.h
@@ -233,7 +233,7 @@ namespace hep::concurrency {
 
   template <detail::hashable_cache_key Key, typename Value>
   template <typename T>
-  requires std::convertible_to<T, Value>
+    requires std::convertible_to<T, Value>
   cache_handle<Key, Value>
   cache<Key, Value>::emplace(Key const& key, T&& value)
   {

--- a/hep_concurrency/detail/cache_hashers.h
+++ b/hep_concurrency/detail/cache_hashers.h
@@ -59,7 +59,7 @@ namespace hep::concurrency::detail {
 
     static size_t
     hash(Key const& key)
-    requires has_std_hash_spec<Key>
+      requires has_std_hash_spec<Key>
     {
       std::hash<Key> hasher;
       return hasher(key);
@@ -67,7 +67,7 @@ namespace hep::concurrency::detail {
 
     static size_t
     hash(Key const& key)
-    requires has_hash_function<Key>
+      requires has_hash_function<Key>
     {
       return key.hash();
     }

--- a/hep_concurrency/detail/cache_hashers.h
+++ b/hep_concurrency/detail/cache_hashers.h
@@ -51,28 +51,23 @@ namespace hep::concurrency::detail {
                               };
 
   template <typename Key>
-  struct collection_hasher : collection_hasher_base<Key> {};
-
-  template <typename Key>
   concept hashable_cache_key = has_std_hash_spec<Key> || has_hash_function<Key>;
 
-  // Satisfies tbb::concurrent_hash_map
-  template <has_std_hash_spec Key>
-  struct collection_hasher<Key> : collection_hasher_base<Key> {
+  template <hashable_cache_key Key>
+  struct collection_hasher : collection_hasher_base<Key> {
     using collection_hasher_base<Key>::equal;
+
     static size_t
     hash(Key const& key)
+    requires has_std_hash_spec<Key>
     {
       std::hash<Key> hasher;
       return hasher(key);
     }
-  };
 
-  template <has_hash_function Key>
-  struct collection_hasher<Key> : collection_hasher_base<Key> {
-    using collection_hasher_base<Key>::equal;
     static size_t
     hash(Key const& key)
+    requires has_hash_function<Key>
     {
       return key.hash();
     }


### PR DESCRIPTION
The previous layout of `collection_hasher` accommodated limitations imposed by the need to support C++17. The removal of that requirement gives flexibility to simplify that layout.