### PR TITLE
Removes unused x86intrins header that broke armv8

### DIFF
--- a/hep_concurrency/tsan.cc
+++ b/hep_concurrency/tsan.cc
@@ -1,7 +1,5 @@
 #include "hep_concurrency/tsan.h"
 
-// #include <x86intrin.h>
-
 namespace hep::concurrency {
   int intentionalDataRace_{0};
   thread_local int ignoreBalance_{0};

--- a/hep_concurrency/tsan.cc
+++ b/hep_concurrency/tsan.cc
@@ -1,6 +1,6 @@
 #include "hep_concurrency/tsan.h"
 
-#include <x86intrin.h>
+// #include <x86intrin.h>
 
 namespace hep::concurrency {
   int intentionalDataRace_{0};


### PR DESCRIPTION
This header should not be included there, nothing in that TU depends on it, and it obviously breaks non x86 builds.